### PR TITLE
fix: using ical endpoint for upcoming events

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,6 @@ setup(
         'requests',
         'lxml',
         'python-dateutil',
+        'icalendar',
     ]
 )


### PR DESCRIPTION
- reading upcoming details from the ical file 
- icelandar dependecy
- venue will be empty most likely

```
DEBUG:root:Got iCal data
INFO:meetupscraper:Skipping event 'Dzień otwarty, bez tematu przewodniego'
INFO:meetupscraper:Skipping event 'CTF-y z Hakierspejsem'
INFO:meetupscraper:Skipping event 'Dzień otwarty, bez tematu przewodniego'
INFO:meetupscraper:Skipping event 'Sprzątanie spejsu'
INFO:meetupscraper:Skipping event 'CTF-y z Hakierspejsem'
INFO:meetupscraper:Skipping event 'Dzień otwarty, bez tematu przewodniego'
INFO:meetupscraper:Skipping event 'CTF-y z Hakierspejsem'
[Event(url='https://www.meetup.com/hakierspejs-%C5%82od%C5%BA/events/306443705/',
       date=datetime.datetime(2025, 3, 19, 18, 0),
       title='Radiowe środy SP7HACK',
       venue=Venue(name='', street='')),
 Event(url='https://www.meetup.com/hakierspejs-%C5%82od%C5%BA/events/306706060/',
       date=datetime.datetime(2025, 4, 2, 17, 0),
       title='Radiowe środy SP7HACK',
       venue=Venue(name='', street='')),
 Event(url='https://www.meetup.com/hakierspejs-%C5%82od%C5%BA/events/jhbbqtyhcgbvb/',
       date=datetime.datetime(2025, 4, 16, 17, 0),
       title='Radiowe środy SP7HACK',
       venue=Venue(name='', street=''))]
```